### PR TITLE
Ability to analyse from existing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # wappalyzer-wrapper
-A simple PHP wrapper for Wappalyzer technology detection
+A simple PHP wrapper for Wappalyzer technology detection.
+
+Wraps up wappalyzer-cli command line client for use in PHP.  This library now also allows you to optionally bypass Wappalyzer's use of zombie to download the page, and instead you can pass in your own HTML, headers etc.
 
 ## Simple usage
 
@@ -28,7 +30,7 @@ foreach ($result->getTechnologyResultsByCategory('Analytics') as $technologyResu
 }
 ```
     
-## Usage with existing data
+## Usage with existing page data
 This client can also be used with existing page data you already have, bypassing wappalyzer's use of Zombie to download the page.  You will need the hostname, URL, response headers, HTML and env vars.  Wappalyzer env vars should be a list of keys from the window object of the page visited, e.g. `['jQuery', 'ga']`.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $existingPageDataRequest = new \Silktide\WappalyzerWrapper\Request\ExistingPageD
 $existingPageDataRequest->setHostname('example.com');
 $existingPageDataRequest->setUrl('https://example.com');
 $existingPageDataRequest->addHeader('Content-Type', 'application/json');
-$existingPageDataRequest->addEnv('ga');
+$existingPageDataRequest->addWindowObjectKey('ga');
 $existingPageDataRequest->setHtml('<html><head><meta name="generator" content="Amiro"></head><body></body></html>');
 
 // Create client

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ $resultFactory = new \Silktide\WappalyzerWrapper\Result\ResultFactory();
 $technologyResultFactory = new \Silktide\WappalyzerWrapper\Result\TechnologyResultFactory();
 $parser = new \Silktide\WappalyzerWrapper\Result\ResultProcessor($resultFactory, $technologyResultFactory);
 $commandFactory = new \Silktide\WappalyzerWrapper\CommandFactory();
+$jsonFileWriter = new \Silktide\WappalyzerWrapper\Request\JsonFileWriter();
 
 // Create client
-$client = new \Silktide\WappalyzerWrapper\Client($commandFactory, $parser);
+$client = new \Silktide\WappalyzerWrapper\Client($commandFactory, $parser, $jsonFileWriter);
 
 // Get the analysis results for a site
 $result = $client->analyse('https://silktide.com');
@@ -27,3 +28,42 @@ foreach ($result->getTechnologyResultsByCategory('Analytics') as $technologyResu
 }
 ```
     
+## Usage with existing data
+This client can also be used with existing page data you already have.  You will need the hostname, URL, response headers, HTML and env vars.  Wappalyzer env vars should be a list of keys from the window object of the page visited, e.g. jQuery, ga.
+
+```php
+
+//Build required classes (can also use DI)
+$resultFactory = new \Silktide\WappalyzerWrapper\Result\ResultFactory();
+$technologyResultFactory = new \Silktide\WappalyzerWrapper\Result\TechnologyResultFactory();
+$parser = new \Silktide\WappalyzerWrapper\Result\ResultProcessor($resultFactory, $technologyResultFactory);
+$commandFactory = new \Silktide\WappalyzerWrapper\CommandFactory();
+$jsonFileWriter = new \Silktide\WappalyzerWrapper\Request\JsonFileWriter();
+
+// Set up request from existing page data
+$existingPageDataRequest = new \Silktide\WappalyzerWrapper\Request\ExistingPageDataRequest();
+
+$existingPageDataRequest->setHostname('example.com');
+$existingPageDataRequest->setUrl('https://example.com');
+$existingPageDataRequest->addHeader('Content-Type', 'application/json');
+$existingPageDataRequest->addEnv('ga');
+$existingPageDataRequest->setHtml('<html><head><meta name="generator" content="Amiro"></head><body></body></html>');
+
+// Create client
+$client = new \Silktide\WappalyzerWrapper\Client($commandFactory, $parser, $jsonFileWriter);
+
+// Get the analysis results for a site
+$result = $client->analyseFromExistingData($existingPageDataRequest);
+
+// Output all technologies found
+foreach ($result->getTechnologyResults() as $technologyResult) {
+    echo "\nFound ".$technologyResult->getName();
+}
+
+// Output just something from a specific category
+foreach ($result->getTechnologyResultsByCategory('Analytics') as $technologyResult) {
+    echo "\nFound ".$technologyResult->getName();
+}
+
+
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wappalyzer-wrapper
-A simple PHP wrapper for Wappalyzer technology detection.
-
-Wraps up wappalyzer-cli command line client for use in PHP.  This library now also allows you to optionally bypass Wappalyzer's use of zombie to download the page, and instead you can pass in your own HTML, headers etc.
+A simple PHP wrapper for Wappalyzer technology detection that wraps up wappalyzer-cli command line client for use as an easily installed composer dependency.
+ 
+This library now also allows you to optionally bypass Wappalyzer's use of zombie to download the page, and instead you can pass in your own HTML, headers etc.
 
 ## Simple usage
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ foreach ($result->getTechnologyResultsByCategory('Analytics') as $technologyResu
 ```
     
 ## Usage with existing data
-This client can also be used with existing page data you already have.  You will need the hostname, URL, response headers, HTML and env vars.  Wappalyzer env vars should be a list of keys from the window object of the page visited, e.g. jQuery, ga.
+This client can also be used with existing page data you already have, bypassing wappalyzer's use of Zombie to download the page.  You will need the hostname, URL, response headers, HTML and env vars.  Wappalyzer env vars should be a list of keys from the window object of the page visited, e.g. `['jQuery', 'ga']`.
 
 ```php
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -74,8 +74,18 @@ class Client
      */
     public function analyseFromExistingData(ExistingPageDataRequest $request)
     {
+        // Get path of our script
         $path = realpath(__DIR__.'/../src/wappalyze.js');
+
+        // Write json to temp file
         $filename = $this->jsonFileWriter->writeToTempFile($request);
-        return $this->executeCommandAndReturnResult('nodejs '.$path.' '.$filename);
+
+        // Execute
+        $result = $this->executeCommandAndReturnResult('nodejs '.$path.' '.$filename);
+
+        // Clean up temp json file
+        $this->jsonFileWriter->remove($filename);
+
+        return $result;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,8 @@
 
 namespace Silktide\WappalyzerWrapper;
 
+use Silktide\WappalyzerWrapper\Request\ExistingPageDataRequest;
+use Silktide\WappalyzerWrapper\Request\JsonFileWriter;
 use Silktide\WappalyzerWrapper\Result\Result;
 use Silktide\WappalyzerWrapper\Result\ResultProcessor;
 
@@ -19,27 +21,31 @@ class Client
     protected $resultProcessor;
 
     /**
+     * @var JsonFileWriter
+     */
+    protected $jsonFileWriter;
+
+    /**
      * Client constructor.
      * @param CommandFactory $commandFactory
      * @param ResultProcessor $resultProcessor
+     * @param JsonFileWriter $jsonFileWriter
      */
-    public function __construct(CommandFactory $commandFactory, ResultProcessor $resultProcessor)
+    public function __construct(CommandFactory $commandFactory, ResultProcessor $resultProcessor, JsonFileWriter $jsonFileWriter)
     {
         $this->commandFactory = $commandFactory;
         $this->resultProcessor = $resultProcessor;
+        $this->jsonFileWriter = $jsonFileWriter;
     }
 
     /**
-     * @param string $url
+     * @param string $command
      * @return Result
      * @throws \Exception
      */
-    public function analyse(string $url)
+    protected function executeCommandAndReturnResult(string $command)
     {
-
-        $path = realpath(__DIR__.'/../node_modules/wappalyzer/index.js');
-
-        $command = $this->commandFactory->create('nodejs '.$path.' '.$url);
+        $command = $this->commandFactory->create($command);
 
         if (!$command->execute()) {
             throw new \Exception("Failed to execute");
@@ -49,6 +55,27 @@ class Client
         $result = $this->resultProcessor->parse($jsonOutput);
 
         return $result;
+    }
 
+    /**
+     * @param string $url
+     * @return Result
+     */
+    public function analyse(string $url)
+    {
+
+        $path = realpath(__DIR__.'/../node_modules/wappalyzer/index.js');
+        return $this->executeCommandAndReturnResult('nodejs '.$path.' '.$url);
+    }
+
+    /**
+     * @param ExistingPageDataRequest $request
+     * @return Result
+     */
+    public function analyseFromExistingData(ExistingPageDataRequest $request)
+    {
+        $path = realpath(__DIR__.'/../src/wappalyze.js');
+        $filename = $this->jsonFileWriter->writeToTempFile($request);
+        return $this->executeCommandAndReturnResult('nodejs '.$path.' '.$filename);
     }
 }

--- a/src/Request/ExistingPageDataRequest.php
+++ b/src/Request/ExistingPageDataRequest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Silktide\WappalyzerWrapper\Request;
+
+class ExistingPageDataRequest
+{
+    /**
+     * @var string[]
+     */
+    protected $headers = [];
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $hostname;
+
+    /**
+     * @var string[]
+     */
+    protected $env = [];
+
+    /**
+     * @var string
+     */
+    protected $html;
+
+    /**
+     * @return \string[]
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @param \string[] $headers
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->headers = [];
+        foreach ($headers as $key => $value) {
+            $this->addHeader($key, $value);
+        }
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function addHeader(string $key, string $value)
+    {
+        $this->headers[$key] = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHostname(): string
+    {
+        return $this->hostname;
+    }
+
+    /**
+     * @param string $hostname
+     */
+    public function setHostname(string $hostname)
+    {
+        $this->hostname = $hostname;
+    }
+
+    /**
+     * @return \string[]
+     */
+    public function getEnv(): array
+    {
+        return $this->env;
+    }
+
+    /**
+     * @param \string[] $env
+     */
+    public function setEnv(array $env)
+    {
+        $this->env = [];
+        foreach ($env as $value) {
+            $this->addEnv($value);
+        }
+    }
+
+    /**
+     * @param string $value
+     */
+    public function addEnv(string $value)
+    {
+        $this->env[] = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+
+    /**
+     * @param string $html
+     */
+    public function setHtml(string $html)
+    {
+        $this->html = $html;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'env' => $this->env,
+            'headers' => $this->headers,
+            'url' => $this->url,
+            'hostname' => $this->hostname,
+            'html' => $this->html
+        ];
+    }
+
+}

--- a/src/Request/ExistingPageDataRequest.php
+++ b/src/Request/ExistingPageDataRequest.php
@@ -12,22 +12,24 @@ class ExistingPageDataRequest
     /**
      * @var string
      */
-    protected $url;
+    protected $url = '';
 
     /**
      * @var string
      */
-    protected $hostname;
+    protected $hostname = '';
 
     /**
+     * Wappalyzer requires a list of keys from the window object of the browser
+     *
      * @var string[]
      */
-    protected $env = [];
+    protected $windowObjectKeys = [];
 
     /**
      * @var string
      */
-    protected $html;
+    protected $html = '';
 
     /**
      * @return \string[]
@@ -92,28 +94,32 @@ class ExistingPageDataRequest
     /**
      * @return \string[]
      */
-    public function getEnv(): array
+    public function getWindowObjectKeys(): array
     {
-        return $this->env;
+        return $this->windowObjectKeys;
     }
 
     /**
-     * @param \string[] $env
+     * Wappalyzer requires a list of keys from the window object of the browser
+     *
+     * @param array $windowObjectKeys
      */
-    public function setEnv(array $env)
+    public function setWindowObjectKeys(array $windowObjectKeys)
     {
-        $this->env = [];
-        foreach ($env as $value) {
-            $this->addEnv($value);
+        $this->windowObjectKeys = [];
+        foreach ($windowObjectKeys as $windowObjectKey) {
+            $this->addWindowObjectKey($windowObjectKey);
         }
     }
 
     /**
-     * @param string $value
+     * Wappalyzer requires a list of keys from the window object of the browser
+     *
+     * @param string $windowObjectKey
      */
-    public function addEnv(string $value)
+    public function addWindowObjectKey(string $windowObjectKey)
     {
-        $this->env[] = $value;
+        $this->windowObjectKeys[] = $windowObjectKey;
     }
 
     /**
@@ -139,7 +145,7 @@ class ExistingPageDataRequest
     public function toArray()
     {
         return [
-            'env' => $this->env,
+            'env' => $this->windowObjectKeys,
             'headers' => $this->headers,
             'url' => $this->url,
             'hostname' => $this->hostname,

--- a/src/Request/JsonFileWriter.php
+++ b/src/Request/JsonFileWriter.php
@@ -35,4 +35,12 @@ class JsonFileWriter
 
         return $tmpFilename;
     }
+
+    /**
+     * @param string $filename
+     */
+    public function remove(string $filename)
+    {
+        unlink($filename);
+    }
 }

--- a/src/Request/JsonFileWriter.php
+++ b/src/Request/JsonFileWriter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Silktide\WappalyzerWrapper\Request;
+
+class JsonFileWriter
+{
+    protected $basePath = '/tmp/';
+
+    /**
+     * @param string $basePath
+     */
+    protected function setBasePath(string $basePath)
+    {
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getRandomFilename()
+    {
+        return $this->basePath."wappalyzer_".md5(uniqid()).".json";
+    }
+
+    /**
+     * @param ExistingPageDataRequest $request
+     * @return string
+     */
+    public function writeToTempFile(ExistingPageDataRequest $request)
+    {
+        $tmpFilename = $this->getRandomFilename();
+
+        $content = json_encode($request->toArray());
+        file_put_contents($tmpFilename, $content);
+
+        return $tmpFilename;
+    }
+}

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -8,7 +8,7 @@ class Result
     /**
      * @var TechnologyResult[]
      */
-    protected $technologyResults;
+    protected $technologyResults = [];
 
     /**
      * @return TechnologyResult[]

--- a/src/wappalyze.js
+++ b/src/wappalyze.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const Wappalyzer = require('../node_modules/wappalyzer/wappalyzer');
+const fs = require('fs');
+
+const wappalyzer = new Wappalyzer();
+
+const args = process.argv.slice(2);
+
+const inputFile = args[0] || '';
+
+if ( !inputFile ) {
+    process.stderr.write('No input file specified\n');
+
+    process.exit(1);
+}
+
+const document = JSON.parse(fs.readFileSync(inputFile));
+const json = JSON.parse(fs.readFileSync('node_modules/wappalyzer/apps.json'));
+
+wappalyzer.apps = json.apps;
+wappalyzer.categories = json.categories;
+
+wappalyzer.driver.log = (message, source, type) => {
+};
+
+wappalyzer.driver.displayApps = detected => {
+    var apps = [];
+
+    Object.keys(detected).forEach(appName => {
+        const app = detected[appName];
+
+        var categories = [];
+
+        app.props.cats.forEach(id => {
+            var category = {};
+
+            category[id] = wappalyzer.categories[id].name;
+
+            categories.push(category)
+        });
+
+        apps.push({
+            name: app.name,
+            confidence: app.confidenceTotal.toString(),
+            version: app.version,
+            icon: app.props.icon || 'default.svg',
+            website: app.props.website,
+            categories
+        });
+    });
+
+    process.stdout.write(JSON.stringify(apps) + '\n');
+    process.exit();
+};
+
+wappalyzer.analyze(
+    document.hostname,
+    document.url, {
+        headers: document.headers,
+        html: document.html,
+        env: document.env
+    }
+);

--- a/src/wappalyze.js
+++ b/src/wappalyze.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * This file allows the use of Wappalyzer without the inbuilt Zombie spider.
+ *
+ * It reads page data from a simple JSON file and outputs the found technologies as JSON.
+ */
+
 const Wappalyzer = require('../node_modules/wappalyzer/wappalyzer');
 const fs = require('fs');
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -49,6 +49,7 @@ class ClientTest extends TestCase
 
         $mockJsonFileWriter = $this->getMockBuilder(JsonFileWriter::class)->getMock();
         $mockJsonFileWriter->expects($this->any())->method('writeToTempFile')->with($examplePageDataRequest)->willReturn($tmpPath);
+        $mockJsonFileWriter->expects($this->atLeastOnce())->method('remove')->with($tmpPath);
 
         $json = '[{"json":"something"}]';
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -6,6 +6,8 @@ use mikehaertl\shellcommand\Command;
 use Silktide\WappalyzerWrapper\Client;
 use PHPUnit\Framework\TestCase;
 use Silktide\WappalyzerWrapper\CommandFactory;
+use Silktide\WappalyzerWrapper\Request\ExistingPageDataRequest;
+use Silktide\WappalyzerWrapper\Request\JsonFileWriter;
 use Silktide\WappalyzerWrapper\Result\Result;
 use Silktide\WappalyzerWrapper\Result\ResultProcessor;
 
@@ -20,6 +22,8 @@ class ClientTest extends TestCase
         $mockCommand->expects($this->atLeastOnce())->method('execute')->willReturn(true);
         $mockCommand->expects($this->atLeastOnce())->method('getOutput')->willReturn($json);
 
+        $mockJsonFileWriter = $this->getMockBuilder(JsonFileWriter::class)->getMock();
+
         // Should use path relative to this test
         $path = realpath(__DIR__.'/../node_modules/wappalyzer/index.js');
 
@@ -31,8 +35,40 @@ class ClientTest extends TestCase
         $resultProcessor = $this->getMockBuilder(ResultProcessor::class)->disableOriginalConstructor()->getMock();
         $resultProcessor->expects($this->exactly(1))->method('parse')->with($json)->willReturn($mockResult);
 
-        $client = new Client($mockCommandFactory, $resultProcessor);
+        $client = new Client($mockCommandFactory, $resultProcessor, $mockJsonFileWriter);
         $actualResult = $client->analyse($url);
+
+        $this->assertEquals($mockResult, $actualResult);
+    }
+
+    public function testClientWithExistingData()
+    {
+        $tmpPath = '/tmp/filename.json';
+
+        $examplePageDataRequest = $this->getMockBuilder(ExistingPageDataRequest::class)->getMock();
+
+        $mockJsonFileWriter = $this->getMockBuilder(JsonFileWriter::class)->getMock();
+        $mockJsonFileWriter->expects($this->any())->method('writeToTempFile')->with($examplePageDataRequest)->willReturn($tmpPath);
+
+        $json = '[{"json":"something"}]';
+
+        $mockCommand = $this->getMockBuilder(Command::class)->getMock();
+        $mockCommand->expects($this->atLeastOnce())->method('execute')->willReturn(true);
+        $mockCommand->expects($this->atLeastOnce())->method('getOutput')->willReturn($json);
+
+        // Should use path relative to this test
+        $path = realpath(__DIR__.'/../src/wappalyze.js');
+
+        $mockCommandFactory = $this->getMockBuilder(CommandFactory::class)->getMock();
+        $mockCommandFactory->expects($this->atLeastOnce())->method('create')->with('nodejs '.$path.' '.$tmpPath)->will($this->returnValue($mockCommand));
+
+        $mockResult = $this->getMockBuilder(Result::class)->getMock();
+
+        $resultProcessor = $this->getMockBuilder(ResultProcessor::class)->disableOriginalConstructor()->getMock();
+        $resultProcessor->expects($this->exactly(1))->method('parse')->with($json)->willReturn($mockResult);
+
+        $client = new Client($mockCommandFactory, $resultProcessor, $mockJsonFileWriter);
+        $actualResult = $client->analyseFromExistingData($examplePageDataRequest);
 
         $this->assertEquals($mockResult, $actualResult);
     }

--- a/test/Request/ExistingPageDataRequestTest.php
+++ b/test/Request/ExistingPageDataRequestTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Silktide\WappalyzerWrapper\Test\Request;
+
+use PHPUnit\Framework\TestCase;
+use Silktide\WappalyzerWrapper\Request\ExistingPageDataRequest;
+
+class ExistingPageDataRequestTest extends TestCase
+{
+    public function testExistingPageDataRequest()
+    {
+        $exampleHeaders = [
+            'Content-Type' => 'text/json',
+            'Content-Encoding' => 'gzip'
+        ];
+
+        $exampleEnv = [
+            'jQuery',
+            'ga'
+        ];
+
+        $exampleHostname = 'hostname.com';
+
+        $exampleUrl = 'https://hostname.com/page.html?var=value';
+
+        $exampleMarkup = '<html></html>';
+
+        $request = new ExistingPageDataRequest();
+        $request->setUrl($exampleUrl);
+        $request->setEnv($exampleEnv);
+        $request->setHeaders($exampleHeaders);
+        $request->setHostname($exampleHostname);
+        $request->setHtml($exampleMarkup);
+
+        $this->assertEquals($exampleUrl, $request->getUrl());
+        $this->assertEquals($exampleHostname, $request->getHostname());
+        $this->assertEquals($exampleEnv, $request->getEnv());
+        $this->assertEquals($exampleHeaders, $request->getHeaders());
+        $this->assertEquals($exampleMarkup, $request->getHtml());
+
+        $asArray = $request->toArray();
+
+        $this->assertArrayHasKey('headers', $asArray);
+        $this->assertArrayHasKey('env', $asArray);
+        $this->assertArrayHasKey('hostname', $asArray);
+        $this->assertArrayHasKey('url', $asArray);
+
+        $this->assertEquals($asArray['url'], $request->getUrl());
+        $this->assertEquals($asArray['hostname'], $request->getHostname());
+        $this->assertEquals($asArray['env'], $request->getEnv());
+        $this->assertEquals($asArray['headers'], $request->getHeaders());
+        $this->assertEquals($asArray['html'], $request->getHtml());
+
+
+    }
+}

--- a/test/Request/ExistingPageDataRequestTest.php
+++ b/test/Request/ExistingPageDataRequestTest.php
@@ -27,14 +27,14 @@ class ExistingPageDataRequestTest extends TestCase
 
         $request = new ExistingPageDataRequest();
         $request->setUrl($exampleUrl);
-        $request->setEnv($exampleEnv);
+        $request->setWindowObjectKeys($exampleEnv);
         $request->setHeaders($exampleHeaders);
         $request->setHostname($exampleHostname);
         $request->setHtml($exampleMarkup);
 
         $this->assertEquals($exampleUrl, $request->getUrl());
         $this->assertEquals($exampleHostname, $request->getHostname());
-        $this->assertEquals($exampleEnv, $request->getEnv());
+        $this->assertEquals($exampleEnv, $request->getWindowObjectKeys());
         $this->assertEquals($exampleHeaders, $request->getHeaders());
         $this->assertEquals($exampleMarkup, $request->getHtml());
 
@@ -47,7 +47,7 @@ class ExistingPageDataRequestTest extends TestCase
 
         $this->assertEquals($asArray['url'], $request->getUrl());
         $this->assertEquals($asArray['hostname'], $request->getHostname());
-        $this->assertEquals($asArray['env'], $request->getEnv());
+        $this->assertEquals($asArray['env'], $request->getWindowObjectKeys());
         $this->assertEquals($asArray['headers'], $request->getHeaders());
         $this->assertEquals($asArray['html'], $request->getHtml());
 

--- a/test/Request/JsonFileWriterTest.php
+++ b/test/Request/JsonFileWriterTest.php
@@ -30,5 +30,9 @@ class JsonFileWriterTest extends TestCase
 
         $this->assertEquals($exampleData, $json);
 
+        $writer->remove($filename);
+
+        $this->assertFileNotExists($filename);
+
     }
 }

--- a/test/Request/JsonFileWriterTest.php
+++ b/test/Request/JsonFileWriterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Silktide\WappalyzerWrapper\Test\Request;
+
+use PHPUnit\Framework\TestCase;
+use Silktide\WappalyzerWrapper\Request\ExistingPageDataRequest;
+use Silktide\WappalyzerWrapper\Request\JsonFileWriter;
+
+class JsonFileWriterTest extends TestCase
+{
+    public function testWriter()
+    {
+        $exampleData = [
+            'key' => 'value',
+            'another' => [
+                'something',
+                'else'
+            ]
+        ];
+
+        $examplePageDataRequest = $this->getMockBuilder(ExistingPageDataRequest::class)->getMock();
+        $examplePageDataRequest->expects($this->any())->method('toArray')->willReturn($exampleData);
+
+        $writer = new JsonFileWriter();
+        $filename = $writer->writeToTempFile($examplePageDataRequest);
+
+        $contents = file_get_contents($filename);
+
+        $json = json_decode($contents, true);
+
+        $this->assertEquals($exampleData, $json);
+
+    }
+}


### PR DESCRIPTION
Skip the wappalyzer-cli inbuilt spider and use existing data you may already have from your own spider.

Just pass in the HTML, URL, headers etc. and get the same output.