### PR TITLE
Fix calls to getVersion() crashing where version is unknown

### DIFF
--- a/src/Result/TechnologyResult.php
+++ b/src/Result/TechnologyResult.php
@@ -67,9 +67,9 @@ class TechnologyResult
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getVersion(): string
+    public function getVersion(): ?string
     {
         return $this->version;
     }


### PR DESCRIPTION
This is breaking Insites, which uses `getVersion()` extensively. 