### PR TITLE
Fix Wappalyzer typo

### DIFF
--- a/install/Installer.php
+++ b/install/Installer.php
@@ -39,7 +39,7 @@ class Installer implements PluginInterface, EventSubscriberInterface
             throw new \Exception("<error>NPM not installed</error>");
         }
 
-        $output->write("<info>Installing Wappalyser</info>");
+        $output->write("<info>Installing Wappalyzer</info>");
         exec("cd {$wappalyzerWrapperDirectory} && npm install", $stdOut, $exitCode);
 
         if ($exitCode !== 0) {


### PR DESCRIPTION
Hi,

Just a little fix typo.
I see it every time I run `composer install` & `composer update` : 

![image](https://user-images.githubusercontent.com/1866496/55065893-fbab8700-507c-11e9-8ef7-902d3e800335.png)

Nice package btw 😄 